### PR TITLE
move selling price to stock model

### DIFF
--- a/saleor/api/purchase_variant/serializers.py
+++ b/saleor/api/purchase_variant/serializers.py
@@ -130,18 +130,22 @@ class TableCreateSerializer(serializers.ModelSerializer):
             raise ValidationError(e)
 
         def create_variant_stock(item, variant):
-            variant.pk = None
-            variant.price_override = item['unit_cost']
-            # combine last id with sku
-            variant.sku = str(variant.sku) + str(ProductVariant.objects.latest('id').id)
-            variant.save()
+            # variant.pk = None
+            # variant.price_override = item['unit_cost']
+            # # combine last id with sku
+            # variant.sku = str(variant.sku) + str(ProductVariant.objects.latest('id').id)
+            # variant.save()
 
             # new stock
             stock = Stock()
             stock.variant = variant
             stock.quantity = item['qty']
             stock.cost_price = item['cost_price']
+            stock.price_override = item['price_override']
+            stock.minimum_price = item['minimum_price']
+            stock.wholesale_override = item['wholesale_override']
             stock.low_stock_threshold = item['low_stock_threshold']
+
             stock.save()
 
         for item in items:
@@ -176,6 +180,12 @@ class TableCreateSerializer(serializers.ModelSerializer):
                         variant = ProductVariant.objects.get(sku=item['sku'])
                         create_variant_stock(item, variant)
                         new_created = True
+                if stock.price_override != item['price_override']:
+                    if not new_created:
+                        # ('create a new  variant')
+                        variant = ProductVariant.objects.get(sku=item['sku'])
+                        create_variant_stock(item, variant)
+                        new_created = True
                 else:
                     print('dont create new variant')
                 if not new_created:
@@ -187,6 +197,9 @@ class TableCreateSerializer(serializers.ModelSerializer):
                     stock.variant = ProductVariant.objects.get(sku=item['sku'])
                     stock.quantity = item['qty']
                     stock.cost_price = item['cost_price']
+                    stock.price_override = item['price_override']
+                    stock.minimum_price = item['minimum_price']
+                    stock.wholesale_override = item['wholesale_override']
                     stock.low_stock_threshold = item['low_stock_threshold']
                     stock.save()
 

--- a/saleor/api/variant/serializers.py
+++ b/saleor/api/variant/serializers.py
@@ -68,7 +68,10 @@ class VariantListSerializer(serializers.ModelSerializer):
 
     def get_discount(self, obj):
         today = date.today()
-        price = obj.get_price_per_item().gross
+        try:
+            price = obj.get_price_per_item().gross
+        except:
+            price = 0
         discounts = Sale.objects.filter(start_date__lte=today).filter(end_date__gte=today)
         discount = 0
         discount_list = get_variant_discounts(obj, discounts)
@@ -102,8 +105,11 @@ class VariantListSerializer(serializers.ModelSerializer):
         return product_name
 
     def get_unit_cost(self, obj):
-        price = obj.get_price_per_item().gross
-        return price
+        try:
+            price = obj.get_price_per_item().gross
+            return price
+        except:
+            return 0
 
     def get_tax(self, obj):
         if obj.product.product_tax:

--- a/saleor/api/variant/views.py
+++ b/saleor/api/variant/views.py
@@ -72,7 +72,8 @@ class VariantProductListAPIView(generics.ListAPIView):
         if self.request.GET.get('supplier'):
             queryset_list = queryset_list.filter(variant_supplier__pk=int(self.request.GET.get('supplier')))
 
-        queryset_list = queryset_list.exclude(stock__quantity__gte=0).filter(product__pk=int(self.kwargs['pk']))
+        # queryset_list = queryset_list.exclude(stock__quantity__gte=0).filter(product__pk=int(self.kwargs['pk']))
+        queryset_list = queryset_list.filter(product__pk=int(self.kwargs['pk']))
         query = self.request.GET.get('q')
         if query:
             queryset_list = queryset_list.filter(

--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -76,9 +76,6 @@ class StockForm(forms.ModelForm):
         field = self.fields['location'] 
         field.widget.attrs['class'] = 'form-control select'
 
-        field = self.fields['payment_options']
-        field.widget.attrs['class'] = 'form-control multiselect'
-
 
 class ProductClassForm(forms.ModelForm):
     class Meta:

--- a/saleor/dashboard/product/views.py
+++ b/saleor/dashboard/product/views.py
@@ -673,9 +673,9 @@ def product_edit(request, pk,name=None):
     attributes = product.product_class.variant_attributes.prefetch_related(
         'values')
     images = product.images.all()
-    variants = product.variants.all()
+    variants = product.variants.all().order_by('-id')
     stock_items = Stock.objects.filter(
-        variant__in=variants).select_related('variant', 'location')
+        variant__in=variants).select_related('variant', 'location').order_by('-id')
 
     form = forms.ProductForm(request.POST or None, instance=product)
     variants_delete_form = forms.VariantBulkDeleteForm()
@@ -1038,12 +1038,6 @@ def add_attributes(request):
                     product_variant.variant_supplier = supplier
                 except:
                     pass
-        if request.POST.get('price'):
-            product_variant.price_override = request.POST.get('price')
-        if request.POST.get('minimum_price'):
-            product_variant.minimum_price = request.POST.get('minimum_price')
-        if request.POST.get('wholesale'):
-            product_variant.wholesale_override = request.POST.get('wholesale')
         if request.POST.get('low_stock_threshold'):
             product_variant.low_stock_threshold = int(request.POST.get('low_stock_threshold'))
         if request.POST.get('attributes'):
@@ -1058,7 +1052,7 @@ def add_attributes(request):
             product = Product.objects.get(pk=int(request.POST.get('pk')))
             product_variant.product = product
             attributes = product.product_class.variant_attributes.prefetch_related('values')    
-            variants = product.variants.all()
+            variants = product.variants.all().order_by('-id')
             product_variant.save()
             ctx = {'product': product,
                    'attributes': attributes,

--- a/saleor/static/backend/js/addProduct.js
+++ b/saleor/static/backend/js/addProduct.js
@@ -201,10 +201,8 @@ $(function() {
       }
       return $(this).data('pk');
     }).get();  
-    // ./mapping    
-    
-    wholePrice  = wholePriceId.val();
-    retailPrice = retailPriceId.val();
+    // ./mapping
+
     newSku      = newSkuId.val();
     reorder_level = reorder_levelId.val();
 
@@ -216,29 +214,9 @@ $(function() {
         return false;
     }
     //validate retail price
-    retailPriceId.on('focusin',function(){
-      $(this).nextAll('.help-block:first').addClass('text-danger').html('');
-    });
-    if(!retailPriceId.val()){
-        retailPriceId.nextAll('.help-block:first').addClass('text-danger').html('Retail price');
-        return false;
-    }
-    //validate minimum price
-    minimumPrice.on('focusin',function(){
-      $(this).nextAll('.help-block:first').addClass('text-danger').html('');
-    });
-    if(!minimumPrice.val()){
-        minimumPrice.nextAll('.help-block:first').addClass('text-danger').html('Fill minimum price');
-        return false;
-    }
-    if(!retailPrice || !newSku || !minimumPrice.val()){
-      alertUser('Retail Price, Minimum price & SKU required','bg-danger','Fill required fields!');
-      return false;
-    }
+
     dynamicData = {};
-    if(wholePrice){
-      dynamicData['wholesale'] = wholePrice;
-    }
+
     if(reorder_level){
       dynamicData['low_stock_threshold'] = reorder_level;
     }
@@ -251,8 +229,6 @@ $(function() {
       //return false;
     }  
     
-    dynamicData['price'] = retailPrice;
-    dynamicData['minimum_price'] = minimumPrice.val();
 
     dynamicData['sku'] = newSku;
     dynamicData['attributes'] = JSON.stringify(json);

--- a/saleor/static/backend/js/edit_variant.js
+++ b/saleor/static/backend/js/edit_variant.js
@@ -21,7 +21,6 @@ $(function(){
   var wprice = editForm.find('#id_wholesale_override');
   var variantSupplier = editForm.find('#id_variant_supplier');
   var dynamic_attrs = editForm.find('.dynamicxedit');
-
   
 
   editvariantBtn.on('click',function(){    
@@ -58,24 +57,11 @@ $(function(){
     }else{
       dynamicData['sku'] = id_sku.val();
     }
-    if(wprice.val()){      
-      dynamicData['wholesale'] = wprice.val();
-    }
+
     if(variantSupplier.val()){
       dynamicData['variant_supplier'] = variantSupplier.val();
     }
-    if(!rprice.val()){
-      alertUser('Retail Price field required','bg-warning','Field Error!');
-      return false;
-    }else{
-      dynamicData['price'] = rprice.val();
-    }
-    if(!minimum_price.val()){
-      alertUser('Minimum Price field required','bg-warning','Field Error!');
-      return false;
-    }else{
-      dynamicData['minimum_price'] = minimum_price.val();
-    }
+
     dynamicData['template'] = 'edit_variant';
     dynamicData['track'] = 'edit variant'
 

--- a/templates/dashboard/product/partials/add_stock_form.html
+++ b/templates/dashboard/product/partials/add_stock_form.html
@@ -16,7 +16,7 @@
     <form id="add-product-stock-form">
     </form>
      <!--product variant-->
-        <div class="col-md-6" style="border-right: 1px solid #373737;">
+        <div class="col-md-4" style="border-right: 1px solid #373737;">
             <!--search filter-->
             <div style="z-index: 1;" class="navbar navbar-default navbar-xs navbar-component">
         <ul class="nav navbar-nav no-border visible-xs-block">
@@ -71,7 +71,6 @@
                             <tr class="bg-primary">
                                 <th>Supplier</th>
                                 <th>Name</th>
-                                <th>SKU</th>
                                 <th>Purchase</th>
                             </tr>
                         </thead>
@@ -96,10 +95,9 @@
                 <template v-for="item in items">
                     <tr class="td animated fadeIn">
                         <td>${item.supplier_name}</td>
-                        <td>${item.product_name}</td>
-                        <td>${item.sku}</td>
+                        <td>${item.product_name}<br>${item.sku}</td>
                         <td class="text-center">
-                            <span class="label label-primary" @click="addToCart(item)">
+                            <span class="label label-primary cursor-pointer" @click="addToCart(item)">
                                 Add
                             </span>
                         </td>
@@ -114,12 +112,12 @@
         </div>
         <!--./variant-->
         <!--cart-->
-        <div class="col-md-6">
+        <div class="col-md-8">
             <div class="panel panel-default">
                 <div class="panelbody table-responsive">
                     <table class="table">
                         <tr class="active">
-                                <td class="text-center text-bold" colspan="5">
+                                <td class="text-center text-bold" colspan="11">
                                     Purchase Cart
                                 </td>
                             </tr>
@@ -128,10 +126,12 @@
                         <thead>
                             <tr class="bg-grey-800">
                                 <th>Name</th>
-                                <th>SKU</th>
                                 <th>Quantity</th>
-                                <th>Cost Price</th>
                                 <th>Reorder Threshold</th>
+                                <th>Cost Price</th>
+                                <th>Retail Price</th>
+                                <th>Wholesale Price</th>
+                                <th>Minimum Price</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -146,17 +146,30 @@
                         <!--listing template-->
                         <template v-for="item in cartItems">
                             <tr class="td animated fadeIn">
-                                <td>${item.product_name}</td>
-                                <td>${item.sku}</td>
+                                <td>${item.product_name}<br>${item.sku}</td>
                                 <td>
                                     <input v-model="item.qty" style="width: 65px;" type="number" placeholder="amount" class="form-control">
-                                </td>
-                                 <td>
-                                    <input v-model="item.cost_price" style="width: 65px;" type="number" placeholder="cost" class="form-control">
                                 </td>
                                 <td>
                                     <input v-model="item.low_stock_threshold" style="width: 65px;" type="number" placeholder="Reorder Thresholder" class="form-control">
                                 </td>
+                                <!--cost price-->
+                                <td>
+                                    <input v-model="item.cost_price" style="width: 65px;" type="number" placeholder="cost" class="form-control">
+                                </td>
+                                <!--retail price-->
+                                <td>
+                                    <input v-model="item.price_override" style="width: 65px;" type="number" placeholder="price_override" class="form-control">
+                                </td>
+                                <!--wholesale price-->
+                                <td>
+                                    <input v-model="item.wholesale_override" style="width: 65px;" type="number" placeholder="wholesale price" class="form-control">
+                                </td>
+                                <!--minimum price-->
+                                <td>
+                                    <input v-model="item.minimum_price" style="width: 65px;" type="number" placeholder="minimum_price" class="form-control">
+                                </td>
+                                <!--options-->
                                 <td>
                                     <span class="label label-white text-grey-800" @click="removeItem(item)">
                                         <i class="icon-trash animated shake"></i>
@@ -174,7 +187,7 @@
                                             <span>Payment</span>
                                         </button>
                                     </td>
-                                    <td colspan="4">
+                                    <td colspan="9">
                                         <span style="font-size:24px;">{{'DEFAULT_CURRENCY'|site_settings}}  ${Total | formatCurrency}</span>
                                     </td>
                                 </template>

--- a/templates/dashboard/product/partials/edit_variant.html
+++ b/templates/dashboard/product/partials/edit_variant.html
@@ -24,9 +24,6 @@
              <th>{{attribute_field.label}}</th>
              {% endfor %}
             {% endif %}
-            <th>Retail Price</th>
-            <th>Wholesale Price</th>
-            <th>Minimum Price</th>
             <th>Supplier</th>
             <th></th>
         </tr>
@@ -45,15 +42,7 @@
                   {% endfor %}
           {% endif %}
           
-           <td>
-            {{form.price_override}}
-            </td>
-            <td>
-              {{form.wholesale_override}}
-            </td>
-              <td>
-                  {{form.minimum_price}}
-              </td>
+
             <!--supplier  -->
             <td>
                 {{form.variant_supplier}}

--- a/templates/dashboard/product/partials/variant_table.html
+++ b/templates/dashboard/product/partials/variant_table.html
@@ -19,13 +19,7 @@
             </th>
           {% endfor %}                  
           
-          <th class="right-align">
-            Retail Price
-          </th>
-          <th class="right-align">
-            Wholesale Price
-          </th>
-          <th>Minimum Price</th>
+
           <th>
               Supplier
           </th>
@@ -46,22 +40,7 @@
               </td>
             {% endfor %}
            
-            <!-- retail price -->
-            <td class="right-align">
-      {% gross variant.get_price_per_item html=True %}
-            </td>
-            <!-- wholesale price -->
-            <td class="right-align">
-            {% if variant.get_wholesale_price_per_item %}
-      {% gross variant.get_wholesale_price_per_item html=True %}
-           {% endif %}
-            </td>
-             <!-- minimum price -->
-            <td class="right-align">
-            {% if variant.minimum_price %}
-            {% gross variant.minimum_price html=True %}
-           {% endif %}
-            </td>
+
             <td>
                 {% if variant.variant_supplier %}
                 {{variant.variant_supplier}}

--- a/templates/dashboard/product/product_form.html
+++ b/templates/dashboard/product/product_form.html
@@ -318,9 +318,7 @@
         {% for v in pc %} 
          <th>{{v}}</th>       
         {% endfor %}
-        <th>Retail Price <span class="text-danger">*</span></th>
-        <th>Wholesale Price</th>
-        <th>Minimum price <span class="text-danger">*</span></th>
+
         <th width="12%">Supplier</th>
         <th></th>
         </tr>
@@ -342,18 +340,7 @@
             </select>
             </td>            
           {% endfor %}
-           <td>
-            <input type="number" placeholder="Retail price" class="form-control" id="rprice" name='rprice'>
-               <span class="help-block text-danger"></span>
-            </td>
-            <td>
-              <input type="number" placeholder="Wholesale Price" class="form-control" id="wprice" name='wprice'>
-                <span class="help-block text-danger"></span>
-            </td>
-            <td>
-              <input type="number" placeholder="Mininum Price" class="form-control" id="mprice" name='mprice'>
-                  <span class="help-block text-danger"></span>
-            </td>
+
             <td>
                 <div class="form-group">
                     <label></label>
@@ -441,17 +428,9 @@
                       <th>
                         {{ attribute.name|capfirst }}
                       </th>
-                    {% endfor %}                  
+                    {% endfor %}
                     
-                    <th class="right-align">
-                      Retail Price
-                    </th>
-                    <th class="right-align">
-                      Wholesale Price
-                    </th>
-                      <th>
-                          Minimum Price
-                      </th>
+
                       <th>
                           Supplier
                       </th>
@@ -473,23 +452,8 @@
                           {{ attr_display }}
                         </td>
                       {% endfor %}
-                     
-                      <!-- retail price -->
-                      <td class="right-align">
-                {% gross variant.get_price_per_item html=True %}
-                      </td>
-                      <!-- wholesale price -->
-                      <td class="right-align">
-                      {% if variant.get_wholesale_price_per_item %}
-                {% gross variant.get_wholesale_price_per_item html=True %}
-                     {% endif %}
-                      </td>
-                   <!--minimum price-->
-                  <td class="right-align">
-                      {% if variant.minimum_price %}
-                {% gross variant.minimum_price html=True %}
-                     {% endif %}
-                      </td>
+
+
                     <td>
                         {% if variant.variant_supplier %}
                         {{variant.variant_supplier}}
@@ -616,6 +580,8 @@
                 <th>
                   Retail Price
                 </th>
+                <th> Wholesale Price</th>
+                <th> Minimum Price</th>
 
                 <!-- <th class="wide">
                   {% trans "Location" context "Stock table header" %}
@@ -626,9 +592,7 @@
                 <th>
                   Reorder Threshold
                 </th>
-                <th class="right-align">
-                  {% trans "Allocated" context "Stock table header" %}
-                </th>
+
                 <th>Options</th>
               </tr>
             </thead>
@@ -648,8 +612,20 @@
                     {% endif %}   
                   </td>
                   <!-- sales price -->
-                  <td> 
-                  {% gross item.variant.get_price_per_item html=True %}
+                  <td>
+                      {% if item.price_override %}
+                  {% gross item.price_override html=True %}
+                      {% endif %}
+                  </td>
+                 <td>
+                     {% if item.wholesale_override %}
+                  {% gross item.wholesale_override html=True %}
+                     {% endif %}
+                  </td>
+                  <td>
+                      {% if item.minimum_price %}
+                  {% gross item.minimum_price html=True %}
+                      {% endif %}
                   </td>
                   
                   
@@ -659,9 +635,7 @@
                   <td>
                     {{item.low_stock_threshold}}
                   </td>
-                  <td class="right-align">
-                    {{ item.quantity_allocated }}
-                  </td>
+
                   <td>
                   <div class="btn-group">
                         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
what:
======================
stock purchase 
- refine auto create stock when user changes cost price/ retail price
- All prices (including retail & Buying price) should be shifted to stock table (done)
- variant price or retail price should be determined by the old stock (done)
- Variant should have a one to many relationship with stock (done)
Product form pricing tab: 
- redo variant CRUD
- add pricing details to purchase cart
- stock CRUD
-  refine stock model 
Sales API endpoint
- use old stock retail price when selling
- display old stock quantity on search stock endpoint
- reduce old stock quantity on a successful sale
- testing create sale using frontend client app