### PR TITLE
Fix Structlog requirement entry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,7 @@ six==1.10.0
 social-auth-app-django==1.1.0
 social-auth-core==1.2.0
 stripe==1.46.0
-structlog=18.2.0
+structlog==18.2.0
 suds-jurko==0.6
 text-unidecode==1.0
 typing==3.5.2.2


### PR DESCRIPTION
#### WHAT
 - fixed the structlog entry in the requirements.txt

#### WHY
 - structlog entry lacked one **" = "** i.e should be ``structlog==18.2.0`` not ``structlog=18.2.0``